### PR TITLE
Reverse parameters of the explode function

### DIFF
--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -34,7 +34,7 @@ final class EmailAddress
      */
     public function __construct($address)
     {
-        $this->localpart = implode(explode('@', $address, -1), '@');
+        $this->localpart = implode('@', explode('@', $address, -1));
         $this->domain    = str_replace($this->localpart.'@', '', $address);
     }
 


### PR DESCRIPTION
Closes [2](https://github.com/GaryJones/EmailAddress/issues/2)

### Feature Description
This PR inverts the parameters of the `explode` function to provide each parameter in the correct order that the function expects and avoid php conflicts.